### PR TITLE
Add Java Spring Boot login example with React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# -
+# Hello Login
+
+简单的 Java Spring Boot 后端配合 React 前端的登录示例。
+
+## 运行
+
+在项目根目录执行:
+
+```bash
+mvn spring-boot:run
+```
+
+然后打开浏览器访问 [http://localhost:8080](http://localhost:8080)。
+
+使用用户名 `admin` 和密码 `password` 可登录成功。

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>hello-login</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>hello-login</name>
+    <description>Simple login page with Java backend and React frontend</description>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/login/LoginApplication.java
+++ b/src/main/java/com/example/login/LoginApplication.java
@@ -1,0 +1,11 @@
+package com.example.login;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LoginApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(LoginApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/login/LoginController.java
+++ b/src/main/java/com/example/login/LoginController.java
@@ -1,0 +1,21 @@
+package com.example.login;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+
+    @PostMapping("/api/login")
+    public Map<String, String> login(@RequestBody Map<String, String> body) {
+        String username = body.getOrDefault("username", "");
+        String password = body.getOrDefault("password", "");
+        if ("admin".equals(username) && "password".equals(password)) {
+            return Map.of("status", "ok");
+        }
+        return Map.of("status", "error", "message", "Invalid credentials");
+    }
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8" />
+    <title>登录</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function LoginForm() {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [message, setMessage] = React.useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if (data.status === 'ok') {
+      setMessage('登录成功');
+    } else {
+      setMessage(data.message || '登录失败');
+    }
+  };
+
+  return (
+    <div>
+      <h2>登录</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input placeholder="用户名" value={username} onChange={e => setUsername(e.target.value)} />
+        </div>
+        <div>
+          <input type="password" placeholder="密码" value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <button type="submit">登录</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<LoginForm />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Set up Maven/Spring Boot project skeleton for a simple login API
- Implement `/api/login` endpoint with hardcoded credential check
- Add React-based login page served from static resources

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899fffdab3c83278335370cf8490f6f