### PR TITLE
feat: enhance login page with extras

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -3,6 +3,49 @@
 <head>
     <meta charset="UTF-8" />
     <title>登录</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background: #f4f6f8;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+      }
+      .login-box {
+        background: #fff;
+        padding: 2rem;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        width: 280px;
+      }
+      .login-box h2 {
+        text-align: center;
+      }
+      .login-box input[type="text"],
+      .login-box input[type="password"],
+      .login-box input[type="checkbox"] {
+        width: 100%;
+        margin: 0.5rem 0;
+        padding: 0.5rem;
+        box-sizing: border-box;
+      }
+      .actions {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .login-box button {
+        width: 100%;
+        padding: 0.5rem;
+        margin-top: 0.5rem;
+      }
+      .message {
+        text-align: center;
+        margin-top: 0.5rem;
+      }
+    </style>
     <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
@@ -11,8 +54,10 @@
 <div id="root"></div>
 <script type="text/babel">
 function LoginForm() {
-  const [username, setUsername] = React.useState('');
+  const [username, setUsername] = React.useState(localStorage.getItem('savedUsername') || '');
   const [password, setPassword] = React.useState('');
+  const [remember, setRemember] = React.useState(!!localStorage.getItem('savedUsername'));
+  const [showPassword, setShowPassword] = React.useState(false);
   const [message, setMessage] = React.useState('');
 
   const handleSubmit = async e => {
@@ -25,24 +70,33 @@ function LoginForm() {
     const data = await res.json();
     if (data.status === 'ok') {
       setMessage('登录成功');
+      if (remember) {
+        localStorage.setItem('savedUsername', username);
+      } else {
+        localStorage.removeItem('savedUsername');
+      }
     } else {
       setMessage(data.message || '登录失败');
     }
   };
 
   return (
-    <div>
+    <div className="login-box">
       <h2>登录</h2>
       <form onSubmit={handleSubmit}>
         <div>
-          <input placeholder="用户名" value={username} onChange={e => setUsername(e.target.value)} />
+          <input type="text" placeholder="用户名" value={username} onChange={e => setUsername(e.target.value)} />
         </div>
-        <div>
-          <input type="password" placeholder="密码" value={password} onChange={e => setPassword(e.target.value)} />
+        <div className="actions">
+          <input type={showPassword ? 'text' : 'password'} placeholder="密码" value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <div className="actions">
+          <label><input type="checkbox" checked={remember} onChange={e => setRemember(e.target.checked)} /> 记住我</label>
+          <label><input type="checkbox" checked={showPassword} onChange={e => setShowPassword(e.target.checked)} /> 显示密码</label>
         </div>
         <button type="submit">登录</button>
       </form>
-      {message && <p>{message}</p>}
+      {message && <p className="message">{message}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add "remember me" and "show password" options to login form
- beautify login page with centered layout and modern styling

## Testing
- `mvn test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a1b68eae08327a38b2080271bb998